### PR TITLE
Add onnx format to predictions to feed fake preds to the Engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ onnx = "1.17.0"
 onnxruntime = "1.18.1"
 pandas = "2.2.3"
 python = ">=3.10,<4.0"
-pyroengine = { git = "https://github.com/pyronear/pyro-engine.git", rev = "main"}
+pyroengine = { git = "https://github.com/pyronear/pyro-engine.git", rev = "feature/parametrize-model-conf"}
 scikit-learn = "1.6.1"
 streamlit = "1.45.0"
 torchvision = "0.21.0"

--- a/scripts/compare_metrics.py
+++ b/scripts/compare_metrics.py
@@ -168,7 +168,7 @@ class GoogleSheetExporter:
                 worksheet = self.spreadsheet.add_worksheet(title=worksheet_name, rows=200, cols=50)
             worksheet.clear()
             set_with_dataframe(worksheet, pd.DataFrame(columns=columns))
-            logging.info(f"{worksheet_name} cleared and initialized with columns")
+            logging.info(f"{worksheet_name} cleared.")
 
     def update_sheet(self, worksheet_name, new_df, key_column="Run ID"):
         try:
@@ -182,7 +182,7 @@ class GoogleSheetExporter:
         except Exception:
             existing_df = pd.DataFrame(columns=new_df.columns)
 
-        new_df[key_column] = new_df[key_column].astype(str)
+        new_df.loc[:, key_column] = new_df[key_column].astype(str)
         filtered_existing = existing_df[~existing_df[key_column].isin(new_df[key_column])]
         final_df = pd.concat([filtered_existing, new_df], ignore_index=True)
 
@@ -219,7 +219,8 @@ if __name__ == "__main__":
 
     eval_dir = os.path.abspath(os.path.join(current_dir, '..', 'data/evaluation'))
 
-    run_dirs = [run for run in glob(f"{eval_dir}/*") if "run-20250619" in run]
+    run_dirs = [run for run in glob(f"{eval_dir}/*") if "run-20250626-13" in run or "run-20250626-14" in run]
+    # run_dirs += [run for run in glob(f"{eval_dir}/*") if "run-20250624-13" in run]
 
     df = build_dataframe(run_dirs, csv_path=None)
     exporter = GoogleSheetExporter("Pyro Metrics")

--- a/src/pyro_eval/data_structures.py
+++ b/src/pyro_eval/data_structures.py
@@ -6,9 +6,9 @@ from typing import List, Optional
 
 import numpy as np
 from PIL import Image as PILImage
+from pyroengine.utils import letterbox
 
 from .utils import parse_date_from_filepath, xywh2xyxy
-
 
 @dataclass
 class CustomImage:
@@ -24,6 +24,7 @@ class CustomImage:
     timestamp: str = field(init=False)
     hash: str = field(init=False)
     prediction: Optional[str] = field(default=None) # Formatted as a 5-array of predictions [[boxes.xyxyn, conf]]
+    image_size = (1024, 1024)
 
     def __post_init__(self):
         self.timestamp = parse_date_from_filepath(self.path)["date"]
@@ -31,7 +32,7 @@ class CustomImage:
         self.label: bool = len(self.boxes) > 0
         self.name: str = os.path.basename(self.path)
 
-    def load(self) -> PILImage.Image:
+    def load(self, resize=False) -> PILImage.Image:
         """
         Load image only when needed
         """
@@ -40,6 +41,9 @@ class CustomImage:
         except:
             image = None
             logging.error(f"Unable to load image : {self.path}")
+        if resize:
+            image, _ = letterbox(np.array(image), self.image_size)
+
         return image
 
     def compute_hash(self):
@@ -69,6 +73,48 @@ class CustomImage:
             logging.warning(f"Failed to parse boxes for image {self.path}: {e}")
             return []
 
+    @property
+    def preds_onnx_format(self):
+        """
+        Convert predictions of shape (N, 5) in xyxyn format + confidence
+        to a pseudo ONNX format to pass into the Engine:
+            - shape (85, N) - transposed compared to ultralytics output
+            - xywh not normalized + conf + placeholder for 80 classes (left empty)
+        """
+
+        preds = np.array(self.prediction)
+        
+        if preds.size == 0:
+            return np.empty((5, 0))
+        
+        boxes_xyxyn = preds[:, :4]  # [x1, y1, x2, y2]
+        confidences = preds[:, 4]   # [conf]
+        
+        # Convert from xyxy to xywh et denormalize
+        x1, y1, x2, y2 = boxes_xyxyn[:, 0], boxes_xyxyn[:, 1], boxes_xyxyn[:, 2], boxes_xyxyn[:, 3]
+
+        w, h = self.image_size
+        x_center = (x1 + x2) / 2 * w
+        y_center = (y1 + y2) / 2 * h
+        width = (x2 - x1) * w
+        height = (y2 - y1) * h
+        
+        # Build array with ONNX format : vertical stack (5, n_detections)
+        onnx_predictions = np.vstack([
+            x_center,
+            y_center,
+            width,
+            height,
+            confidences
+        ])
+        
+        return onnx_predictions
+
+    def resize(self):
+        """
+        Resize to target size and apply letterbox algorithm
+        """
+        
 
 class Sequence:
     """

--- a/src/pyro_eval/evaluation.py
+++ b/src/pyro_eval/evaluation.py
@@ -87,9 +87,7 @@ class EvaluationPipeline:
         model_config = config.get("model", {})
         model_config.setdefault("model_path", config.get("model_path"))
         model_config.setdefault("iou", model_default_values["iou"])
-        # model_config.setdefault("conf", model_default_values["conf"])
-        # FIXME : in the engine we instanciate with conf=0.05 but the value is hardcoded hence can't be retrieved
-        model_config.setdefault("conf", 0.05)
+        model_config.setdefault("conf", engine_default_values["model_conf_thresh"])
         model_config.setdefault("imgsz", model_default_values["imgsz"])
 
         config.setdefault("eval", ["model", "engine"])
@@ -108,6 +106,7 @@ class EvaluationPipeline:
             self.metrics["engine_metrics"] = self.engine_evaluator.evaluate()
 
         self.display_metrics()
+        return self.metrics
 
     def save_metrics(self, save_dir: Path):
         """

--- a/src/pyro_eval/model.py
+++ b/src/pyro_eval/model.py
@@ -16,16 +16,15 @@ class Model:
     def __init__(
             self,
             model_path: str,
-            inference_params : Dict,
+            config : Dict,
             device: str = None,
         ):
 
         self.model_path = model_path
+        self.config = self.set_config(config)
         self.model = self.load_model()
-        self.device = self.get_device(device)
-        self.model.to(self.device)
+        self.set_device(device)
         self.format = None
-        self.inference_params = self.set_inference_params(inference_params)
         self.hash = self.model_hash()
 
     def load_model(self):
@@ -64,7 +63,7 @@ class Model:
             model = Classifier(
                 model_path=self.model_path,
                 format="onnx",
-                conf=self.inference_params["conf"],
+                conf=self.config["conf"],
                 max_bbox_size=1
             )
         except Exception as e:
@@ -106,34 +105,37 @@ class Model:
         # All checks are correct, return the model
         return YOLO(self.model_path)
 
-    def get_device(self, device):
+    def set_device(self, device):
         """
         Returns proper devide depending on configuration
         """
         if device is not None:
-            return torch.device(device)
+            self.device = torch.device(device)
         elif torch.backends.mps.is_available():
-            return torch.device("mps")
+            self.device = torch.device("mps")
         elif torch.cuda.is_available():
-            return torch.device("cuda")
+            self.device = torch.device("cuda")
         else:
-            return torch.device("cpu")
+            self.device = torch.device("cpu")
+        
+        if self.format != "onnx":
+            self.model.to(self.device)
 
-    def set_inference_params(self, inference_params):
+    def set_config(self, config):
         """
         Retrieve Classifier default parameters
         """
         default_params = get_class_default_params(Classifier)
-        inference_params.setdefault("conf", default_params["conf"])
-        inference_params.setdefault("iou", default_params["iou"])
-        inference_params.setdefault("imgsz", default_params["imgsz"])
-        return inference_params
+        config.setdefault("conf", default_params["conf"])
+        config.setdefault("iou", default_params["iou"])
+        config.setdefault("imgsz", default_params["imgsz"])
+        return config
 
     def inference(self, image: CustomImage):
         """
         Reads an image and run the model on it.
         """
-        pil_image = image.load()
+        pil_image = image.load(resize=True)
 
         if self.format == "onnx":
             try:
@@ -146,9 +148,9 @@ class Model:
             try:
                 results = self.model.predict(
                     source=pil_image,
-                    conf=self.inference_params["conf"],
-                    iou=self.inference_params["iou"],
-                    imgsz=self.inference_params["imgsz"],
+                    conf=self.config["conf"],
+                    iou=self.config["iou"],
+                    imgsz=self.config["imgsz"],
                     device=self.device,
                 )[0]
                 # Format predictions to onnx format : [[boxes.xyxyn, conf]]


### PR DESCRIPTION
In this PR we add a way to express predictions in the onnx format which differs from ultralytics, in order to pass fake_preds in the Engine. Also a proper resizing of the image is added, similar to what is done in the Engine

For this to work properly, a modification is needed on the engine as well, which is why the pyproject.toml *temporarily* points toward this branch of pyro-engine: https://github.com/pyronear/pyro-engine/pull/278

Engine must be merged first