### PR TITLE
Add DVC tracking to roc curve files

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,2 @@
 /predictions
+/roc

--- a/data/roc.dvc
+++ b/data/roc.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: b19adc6cb5d3d26408557fd1acdaecd7.dir
+  size: 201360
+  nfiles: 7
+  hash: md5
+  path: roc


### PR DESCRIPTION
When evaluating a model, we automatically compute a roc curve and save it to data/_model_hash_.json
Those files are now tracked with DVC as the predictions files.

